### PR TITLE
correction on test if token is valid

### DIFF
--- a/cmotion/ionic-keycloak-auth/src/lib/service/keycloak-auth.service.ts
+++ b/cmotion/ionic-keycloak-auth/src/lib/service/keycloak-auth.service.ts
@@ -247,7 +247,7 @@ export class KeycloakAuthService {
     if (!authToken) {
       return false;
     }
-    return jwtHelperService.isTokenExpired(authToken.access_token, 10);
+    return !jwtHelperService.isTokenExpired(authToken.access_token, 10);
   }
 
   private async initKeycloakInstance() {


### PR DESCRIPTION
I think there a mistake in isValid() method. If token is expired then token is not valid. 